### PR TITLE
added petsc import to simplify import structure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,8 @@ exclude =
     docs/source/conf.py
     legacy
 max-line-length = 79
-ignore = # Ignore some style 'errors' produced while formatting by 'black'
+ignore =
+         # Ignore some style 'errors' produced while formatting by 'black'
          E203,
 	 W503,
-	 W605  
+	 W605,  

--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,7 @@ exclude =
     docs/source/conf.py
     legacy
 max-line-length = 79
-ignore = E203, W503, W605  # Ignore some style 'errors' produced while formatting by 'black'
+ignore = # Ignore some style 'errors' produced while formatting by 'black'
+         E203,
+	 W503,
+	 W605  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         bash scripts/install.sh test
 
     - name: Run serial tests
-      run: pytest -v --cov --cov-report xml --cov-append ggce/_tests/*.py
+      run: pytest -v --cov --cov-report xml --cov-append ggce/_tests/*.py --runslow
 
     - name: Setup MPI
       uses: mpi4py/setup-mpi@v1
@@ -132,7 +132,7 @@ jobs:
       run: pip install mpi4py pytest-mpi
 
     - name: Run MPI tests
-      run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
+      run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py --runslow
 
     - name: Setup PETSc
       run: pip install petsc petsc4py
@@ -140,7 +140,7 @@ jobs:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 
     - name: Run PETSc tests
-      run: mpiexec -n 4 coverage run --rcfile=ggce/_tests/petsc/setup_pytest_petsc_mpi.cfg -m pytest -v --with-mpi ggce/_tests/petsc/*.py
+      run: mpiexec -n 4 coverage run --rcfile=ggce/_tests/petsc/setup_pytest_petsc_mpi.cfg -m pytest -v --with-mpi ggce/_tests/petsc/*.py --runslow
 
     - name: Combine coverage reports from all ranks and generate xml report
       run: coverage combine && coverage xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         bash scripts/install.sh test
 
     - name: Run serial tests
-      run: pytest -v --cov --cov-report xml --cov-append ggce/_tests/*.py --runslow
+      run: pytest -v --cov --cov-report xml --cov-append ggce/_tests/*.py
 
     - name: Setup MPI
       uses: mpi4py/setup-mpi@v1
@@ -132,7 +132,7 @@ jobs:
       run: pip install mpi4py pytest-mpi
 
     - name: Run MPI tests
-      run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py --runslow
+      run: mpiexec -n 2 coverage run --rcfile=ggce/_tests/mpi/setup_pytest_mpi.cfg -m pytest -v --with-mpi ggce/_tests/mpi/*.py
 
     - name: Setup PETSc
       run: pip install petsc petsc4py
@@ -140,7 +140,7 @@ jobs:
         PETSC_CONFIGURE_OPTIONS: "--with-scalar-type=complex --download-mumps --download-scalapack"
 
     - name: Run PETSc tests
-      run: mpiexec -n 4 coverage run --rcfile=ggce/_tests/petsc/setup_pytest_petsc_mpi.cfg -m pytest -v --with-mpi ggce/_tests/petsc/*.py --runslow
+      run: mpiexec -n 4 coverage run --rcfile=ggce/_tests/petsc/setup_pytest_petsc_mpi.cfg -m pytest -v --with-mpi ggce/_tests/petsc/*.py
 
     - name: Combine coverage reports from all ranks and generate xml report
       run: coverage combine && coverage xml

--- a/ggce/__init__.py
+++ b/ggce/__init__.py
@@ -2,6 +2,7 @@ from .logger import logger  # noqa
 from .model import Model  # noqa
 from .engine.system import System  # noqa
 from .executors.solvers import SparseSolver, DenseSolver  # noqa
+from .executors.petsc4py.solvers import MassSolverMUMPS  # noqa
 
 
 # DO NOT CHANGE ANYTHING BELOW THIS

--- a/ggce/__init__.py
+++ b/ggce/__init__.py
@@ -2,8 +2,10 @@ from .logger import logger  # noqa
 from .model import Model  # noqa
 from .engine.system import System  # noqa
 from .executors.solvers import SparseSolver, DenseSolver  # noqa
-from .executors.petsc4py.solvers import MassSolverMUMPS  # noqa
-
+try:
+    from .executors.petsc4py.solvers import MassSolverMUMPS  # noqa
+except ImportError:
+    pass
 
 # DO NOT CHANGE ANYTHING BELOW THIS
 __version__ = ...  # semantic-version-placeholder

--- a/ggce/__init__.py
+++ b/ggce/__init__.py
@@ -2,6 +2,7 @@ from .logger import logger  # noqa
 from .model import Model  # noqa
 from .engine.system import System  # noqa
 from .executors.solvers import SparseSolver, DenseSolver  # noqa
+
 try:
     from .executors.petsc4py.solvers import MassSolverMUMPS  # noqa
 except ImportError:


### PR DESCRIPTION
Quick fix to allow PETSc solver import to be done the same way as all other GGCE objects. Merging this will close #66.